### PR TITLE
Allow importing as a module. Added prefix argument to allow building …

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,18 +12,19 @@ It currently supports Windows x86/x64, Linux x86/x64 & arm/arm64 architectures.
 
 ## Usage
 ```
-img2sdat.py <system_img> [outdir] [version]
+img2sdat.py <system_img> [-o outdir] [-v version] [-p prefix]
 ```
 - `<system_img>` = input system image
-- `[outdir]` = output directory (current directory by default)
-- `[version]` = transfer list version number (1 - 5.0, 2 - 5.1, 3 - 6.0, 4 - 7.0, will be asked by default, more info on xda thread)
+- `[-o outdir]` = output directory (current directory by default)
+- `[-v version]` = transfer list version number (1 - 5.0, 2 - 5.1, 3 - 6.0, 4 - 7.0, will be asked by default, more info on xda thread)
+- `[-p prefix]` = name of image (prefix.new.dat)
 
 
 
 ## Example
 This is a simple example on a Linux system:
 ```
-~$ ./img2sdat.py system.img tmp 4
+~$ ./img2sdat.py system.img -o tmp -v 4
 ```
 It will create files `system.new.dat`, `system.patch.dat`, `system.transfer.list` in directory `tmp`.
 

--- a/img2sdat.py
+++ b/img2sdat.py
@@ -11,79 +11,89 @@ from __future__ import print_function
 import sys, os, errno, tempfile
 import common, blockimgdiff, sparse_img
 
-__version__ = '1.6'
-
-if sys.hexversion < 0x02070000:
-    print >> sys.stderr, "Python 2.7 or newer is required."
-    try:
-       input = raw_input
-    except NameError: pass
-    input('Press ENTER to exit...')
-    sys.exit(1)
-else:
-    print('img2sdat binary - version: %s\n' % __version__)
-
-try:
-    INPUT_IMAGE = str(sys.argv[1])
-except IndexError:
-    print('Usage: img2sdat.py <system_img> [outdir] [version]\n')
-    print('    <system_img>: input system image\n')
-    print('    [outdir]: output directory (current directory by default)\n')
-    print('    [version]: transfer list version number, will be asked by default - more info on xda thread)\n')
-    print('Visit xda thread for more information.\n')
-    try:
-       input = raw_input
-    except NameError: pass
-    input('Press ENTER to exit...')
-    sys.exit()
-
-def main(argv):
+def main(INPUT_IMAGE, OUTDIR='.', VERSION=None, PREFIX='system'):
     global input
 
-    if len(sys.argv) < 3:
-        outdir = './system'
-    else:
-        outdir = sys.argv[2] + '/system'
+    __version__ = '1.6'
 
-    if len(sys.argv) < 4:
-        version = 4
-        item = True
-        while item:
+    if sys.hexversion < 0x02070000:
+        print >> sys.stderr, "Python 2.7 or newer is required."
+        try:
+            input = raw_input
+        except NameError: pass
+        input('Press ENTER to exit...')
+        sys.exit(1)
+    else:
+        print('img2sdat binary - version: %s\n' % __version__)
+        
+    if not os.path.isdir(OUTDIR):
+        os.makedirs(OUTDIR)
+
+    OUTDIR = OUTDIR + '/'+ PREFIX
+
+    if not VERSION:
+        VERSION = 4
+        while True:
             print('''            1. Android Lollipop 5.0
             2. Android Lollipop 5.1
             3. Android Marshmallow 6.0
-            4. Android Nougat 7.0/7.1/8.0
+            4. Android Nougat 7.0/7.1/8.0/8.1
             ''')
             try:
                 input = raw_input
             except NameError: pass
             item = input('Choose system version: ')
             if item == '1':
-                version = 1
+                VERSION = 1
                 break
             elif item == '2':
-                version = 2
+                VERSION = 2
                 break
             elif item == '3':
-                version = 3
+                VERSION = 3
                 break
             elif item == '4':
-                version = 4
+                VERSION = 4
                 break
             else:
                 return
-    else:
-        version = int(sys.argv[3])
 
     # Get sparse image
     image = sparse_img.SparseImage(INPUT_IMAGE, tempfile.mkstemp()[1], '0')
 
     # Generate output files
-    b = blockimgdiff.BlockImageDiff(image, None, version)
-    b.Compute(outdir)
+    b = blockimgdiff.BlockImageDiff(image, None, VERSION)
+    b.Compute(OUTDIR)
 
-    print('Done! Output files: %s' % os.path.dirname(outdir))
+    print('Done! Output files: %s' % os.path.dirname(OUTDIR))
     return
 
 if __name__ == '__main__':
-    main(sys.argv)
+    import argparse
+
+    parser = argparse.ArgumentParser(description='Visit xda thread for more information.')
+    parser.add_argument('image', help='input system image')
+    parser.add_argument('-o', '--outdir', help='output directory (current directory by default)')
+    parser.add_argument('-v', '--version', help='transfer list version number, will be asked by default - more info on xda thread)')
+    parser.add_argument('-p', '--prefix', help='name of image (prefix.new.dat)')
+
+    args = parser.parse_args()
+
+    INPUT_IMAGE = args.image
+    
+    if args.outdir:
+        OUTDIR = args.outdir
+    else:
+        OUTDIR = '.'
+
+    if args.version:
+        VERSION = int(args.version)
+    else:
+        VERSION = None
+    
+    if args.prefix:
+        PREFIX = args.prefix
+    else:
+        PREFIX = 'system'
+    
+    main(INPUT_IMAGE, OUTDIR, VERSION, PREFIX)


### PR DESCRIPTION
…prefix.new.dat. Added argument parsing when run as a script to allow mixing options. Fixed directories not being created when outdir argument is provided causing a crash.

**Usage as a script is different, and the README has been updated:**
```
./img2sdat vendor.img -o tmp -v 4 -p vendor
```
The default prefix is "system" if -p is not used.


**Usage as a module:**
```
import img2sdat

img2sdat.main(INPUT_IMAGE, OUTDIR='.', VERSION=None, PREFIX='system')
```

Looks like this also fixes issue #12 and #13 :)