### PR TITLE
common: Deprecate imp

### DIFF
--- a/common.py
+++ b/common.py
@@ -18,7 +18,7 @@ import copy
 import errno
 import getopt
 import getpass
-import imp
+import importlib
 import os
 import platform
 import re


### PR DESCRIPTION
imp is deprecated, switch to importlib for python 3.12 and above.